### PR TITLE
Fix rubygems update

### DIFF
--- a/src/orb.yml
+++ b/src/orb.yml
@@ -39,7 +39,7 @@ commands:
         type: boolean
     steps:
       - run: npm install
-      - run: gem update --system
+      - run: sudo gem update --system
       - run: gem install bundler
 
       - restore_cache:


### PR DESCRIPTION
We have just started getting the following error on builds:

```
Permission denied @ rb_sysopen - /usr/local/lib/ruby/site_ruby/2.4.0/rubygems/mock_gem_ui.rb
```

This occurs when the `gem update --system` command is issued.

Here is an example build with the failure:
https://circleci.com/gh/spyscape/website/2624

Running the command with sudo fixes the permissions issue.