### PR TITLE
Fix orb-tools configuration

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,7 +21,6 @@ jobs:
       - orb-tools/publish:
           orb-path: src/orb.yml
           orb-ref: spyscape/rails-orb@dev:$CIRCLE_BRANCH-$CIRCLE_SHA1
-          token-variable: $CIRCLE_TOKEN
 
 workflows:
   version: 2


### PR DESCRIPTION
Due to this https://github.com/CircleCI-Public/orb-tools-orb/commit/a4e41431ebf5c6b921960312e2543ea96b696181
The `$` must be omitted when providing the `token-variable`.

However, the default value is `CIRCLE_TOKEN`, so we don't need to
provide this param at all.