### PR TITLE
Rebuild assets for staging/production

### DIFF
--- a/src/orb.yml
+++ b/src/orb.yml
@@ -70,13 +70,18 @@ commands:
       - when:
           condition: << parameters.build-assets >>
           steps:
-            - run: RAILS_ENV=test bundle exec rake assets:precompile
+            - run: bundle exec rake assets:precompile
+
+      - run: << parameters.test-command >>
+
+      - when:
+          condition: << parameters.build-assets >>
+          steps:
+            - run: RAILS_ENV=production bundle exec rake assets:precompile
             - persist_to_workspace:
                 root: .
                 paths:
                   - public
-
-      - run: << parameters.test-command >>
 
 jobs:
   build:


### PR DESCRIPTION
What we push to S3 cannot be the assets built using the `RAILS_ENV=test`
environment. `test` asset compilation is substantially different to
staging/production asset compilation.