### PR TITLE
Allow CI builds to collect and publish artifacts

### DIFF
--- a/src/orb.yml
+++ b/src/orb.yml
@@ -43,6 +43,8 @@ commands:
         type: boolean
       npm-install:
         type: boolean
+      collect-artifacts:
+        type: boolean
     steps:
       - when:
           condition: << parameters.npm-install >>
@@ -79,6 +81,12 @@ commands:
 
       - run: << parameters.test-command >>
 
+      - when:
+          condition: << parameters.collect-artifacts >>
+          steps:
+            - store_artifacts:
+                path: coverage
+
 jobs:
   build:
     description: Builds a Rails app
@@ -112,6 +120,10 @@ jobs:
         default: false
         description: Whether we want to install NPM pacakges or not
         type: boolean
+      collect-artifacts:
+        default: false
+        description: Whether we want to collect output artifacts
+        type: boolean
     executor:
       name: default
       ruby-version: << parameters.ruby-version >>
@@ -127,3 +139,4 @@ jobs:
           pg-db: << parameters.pg-db >>
           build-assets: << parameters.build-assets >>
           npm-install: << parameters.npm-install >>
+          collect-artifacts: << parameters.collect-artifacts >>


### PR DESCRIPTION
In situations where our CI build is dependent upon a given level of code coverage (often 100%) it is useful to see where any coverage deficiencies lie in situations where CI fails for coverage reasons.

This update to the rails-orb adds an additional, optional step to publish the results of the code coverage to Circle CI's `artfifacts` tab. If enabled, the coverage report and its associated assets will be listed on the tab; clicking on `coverage/index.html` will show the full coverage dataset.

As this is a new step, it is disabled by default. To add the step to applicable repo builds, a `collect-artifacts` parameter should be added to the `rails/build` parameter list﻿in `.circleci/config.yml`, e.g.:

```yaml
jobs:
  - rails/build:
      ruby-version: 2.6.5
      image-options: -node-browsers
      build-assets: true
      pg-db: monocle_test
      collect-artifacts: true
```
