### PR TITLE
Revert to previous Postgres 9.6 trust behaviour

### DIFF
--- a/src/orb.yml
+++ b/src/orb.yml
@@ -31,6 +31,7 @@ executors:
         environment:
           POSTGRES_USER: << parameters.pg-user >>
           POSTGRES_DB: << parameters.pg-db >>
+          POSTGRES_HOST_AUTH_METHOD: trust
 
 commands:
   build-app:


### PR DESCRIPTION
Newer builds of the Docker PostgreSQL image require tighter security by default, requiring that created users also have passwords set. While that's sensible outside CI, here we just want to maintain the existing behaviour for the least possible disruption.

https://discuss.circleci.com/t/postgresql-image-password-not-specified-issue/34555