### PR TITLE
Use cimg for images rather than circleci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  orb-tools: circleci/orb-tools@volatile
+  orb-tools: circleci/orb-tools@10.1.0
   cli: circleci/circleci-cli@volatile
 
 jobs:

--- a/src/orb.yml
+++ b/src/orb.yml
@@ -27,7 +27,7 @@ executors:
         type: boolean
 
     docker:
-      - image: circleci/ruby:<< parameters.ruby-version >><< parameters.image-options >>
+      - image: cimg/ruby:<< parameters.ruby-version >><< parameters.image-options >>
         environment:
           RAILS_ENV: test
           RACK_ENV: test


### PR DESCRIPTION
Locks orb-tools at 10.x as 11.x seems to lose the `validate` command